### PR TITLE
Fixed Tor Logo Issue

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,7 +5,7 @@ body{
 
 /* Code Needed for Tor Logo */
 .torlogo{
-	height:200%;
+	height:40px;
 	margin-top:-10px;
 }
 


### PR DESCRIPTION
Tor Logo was being sized using percentage. Since switching to pixels doesn't affect the responsive size, but does solve the Safari #7 issue here, I have gone ahead and made that change.
