### PR TITLE
Fix issue #24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ WORKDIR /torpaste
 # Install the required software
 RUN pip install -r requirements.txt
 
-# Hack to use UTF-8 instead of ASCII
-RUN echo "import sys; sys.setdefaultencoding('utf-8')" > /usr/lib/python2.7/site-packages/sitecustomize.py
-
 # Expose port *80*
 EXPOSE 80
 

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -1,6 +1,5 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
-✓1
 
 import exceptions as e
 import os

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -72,7 +72,7 @@ def updatePasteMetadata(pasteid, metadata):
 
 	try:
 		for k, v in metadata.iteritems():
-			with open(ppath + "." + k, "w+") as fd:
+			with codecs.open(ppath + "." + k, "w+") as fd:
 				fd.write(v)
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")
@@ -122,7 +122,7 @@ def getPasteMetadata(pasteid):
 		for f in os.listdir("pastes/" + a + "/" + b + "/"):
 			if (pasteid in f) and ("." in f):
 				t = f.split(".")[1]	
-				with open("pastes/" + a + "/" + b + "/" + f, "r") as fd:
+				with codecs.open("pastes/" + a + "/" + b + "/" + f, "r") as fd:
 					ret[t] = fd.read()
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -72,7 +72,7 @@ def updatePasteMetadata(pasteid, metadata):
 
 	try:
 		for k, v in metadata.iteritems():
-			with codecs.open(ppath + "." + k, "w+") as fd:
+			with codecs.open(ppath + "." + k, encoding="utf-8", mode="w+") as fd:
 				fd.write(v)
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")
@@ -101,7 +101,7 @@ def getPasteContents(pasteid):
 	b = pasteid[2:4]
 
 	try:
-		with codecs.open("pastes/" + a + "/" + b + "/" + pasteid, encoding="utf-8") as fd:
+		with codecs.open("pastes/" + a + "/" + b + "/" + pasteid, encoding="utf-8", mode="r") as fd:
 			return fd.read()
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")
@@ -122,7 +122,7 @@ def getPasteMetadata(pasteid):
 		for f in os.listdir("pastes/" + a + "/" + b + "/"):
 			if (pasteid in f) and ("." in f):
 				t = f.split(".")[1]	
-				with codecs.open("pastes/" + a + "/" + b + "/" + f, "r") as fd:
+				with codecs.open("pastes/" + a + "/" + b + "/" + f, encoding="utf-8", mode="r") as fd:
 					ret[t] = fd.read()
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -1,4 +1,6 @@
 #!../bin/python
+# -*- coding: utf-8 -*-
+✓1
 
 import exceptions as e
 import os

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -2,6 +2,7 @@
 
 import exceptions as e
 import os
+import codecs
 
 # initializeBackend()
 ## This method is called when the Flask application starts. Here you can do
@@ -35,7 +36,7 @@ def newPaste(pasteid, pastecontent):
 	ppath = "pastes/" + a + "/" + b + "/" + pasteid
 
 	try:
-		with open(ppath, "w+") as fd:
+		with codecs.open(ppath, encoding="utf-8", mode="w+") as fd:
 			fd.write(pastecontent)
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem perists, try notifying a system administrator.")
@@ -93,7 +94,7 @@ def getPasteContents(pasteid):
 	b = pasteid[2:4]
 
 	try:
-		with open("pastes/" + a + "/" + b + "/" + pasteid) as fd:
+		with codecs.open("pastes/" + a + "/" + b + "/" + pasteid, encoding="utf-8") as fd:
 			return fd.read()
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")

--- a/torpaste.py
+++ b/torpaste.py
@@ -4,6 +4,7 @@ from flask import *
 from hashlib import sha256
 from datetime import datetime
 import os, time
+import codecs
 import backends.filesystem as b
 app = Flask(__name__)
 
@@ -31,7 +32,7 @@ def newpaste():
 	else:
 		if(request.form['content']):
 			try:
-				PasteID = str(sha256(request.form['content']).hexdigest())
+				PasteID = str(sha256(request.form['content'].encode('utf-8')).hexdigest())
 			except:
 				return render_template(
 					"index.html",

--- a/torpaste.py
+++ b/torpaste.py
@@ -147,7 +147,7 @@ def viewpaste(pasteid):
 		)
 
 	PasteDate = datetime.fromtimestamp(int(PasteDate) + time.altzone + 3600).strftime("%H:%M:%S %d/%m/%Y")
-	PasteSize = formatSize(len(PasteContent))
+	PasteSize = formatSize(len(PasteContent.encode('utf-8')))
 	return render_template(
 		"view.html",
 		content = PasteContent,

--- a/torpaste.py
+++ b/torpaste.py
@@ -39,7 +39,7 @@ def newpaste():
 					title = WEBSITE_TITLE,
 					version = VERSION,
 					page = "new",
-					error = "The current version of TorPaste supports ASCII characters only. UTF-8 support is coming soon."
+					error = "An issue occured while handling the paste. Please try again later. If the problem persists, try notifying a system administrator."
 				)
 			try:
 				b.newPaste(PasteID, request.form['content'])

--- a/torpaste.py
+++ b/torpaste.py
@@ -4,7 +4,6 @@ from flask import *
 from hashlib import sha256
 from datetime import datetime
 import os, time
-import codecs
 import backends.filesystem as b
 app = Flask(__name__)
 

--- a/torpaste.py
+++ b/torpaste.py
@@ -1,4 +1,5 @@
 #!bin/python
+# -*- coding: utf-8 -*-
 
 from flask import *
 from hashlib import sha256


### PR DESCRIPTION
This pull request fixes issue #24. By encoding the received paste as UTF-8, the paste ID can be generated properly without raising an exception. In the filesystem backend, using the "codecs" module allows UTF-8 content to be written to a file, then read from it and displayed by Flask.

 I also changed the error message in the exception thrown if the paste ID generation fails. It should not fail anymore, but if for some reason it does, the reason is not lack of UTF-8 support anymore.
