### PR TITLE
Fixed #30 (using word-wrap)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -26,3 +26,7 @@ span.hamburger {
     	width: 100%;
     }
 }
+
+.pastes {
+	word-wrap: break-word;
+}

--- a/templates/list.html
+++ b/templates/list.html
@@ -21,7 +21,7 @@
 							<a href="/new" class="list-group-item">No pastes yet</a>
 							{% else %}
 							{% for paste in pastes %}
-							<a href="/view/{{paste}}" class="list-group-item">{{paste}}</a>
+							<a href="/view/{{paste}}" class="list-group-item pastes">{{paste}}</a>
 							{% endfor %}
 							{% endif %}
 						</div>

--- a/templates/list.html
+++ b/templates/list.html
@@ -16,12 +16,12 @@
 				</div>
 				<div class="row">
 					<div class="col-xs-10 col-xs-offset-1">
-						<div class="list-group">
+						<div class="list-group pastes">
 							{% if "none" in pastes %}
 							<a href="/new" class="list-group-item">No pastes yet</a>
 							{% else %}
 							{% for paste in pastes %}
-							<a href="/view/{{paste}}" class="list-group-item pastes">{{paste}}</a>
+							<a href="/view/{{paste}}" class="list-group-item">{{paste}}</a>
 							{% endfor %}
 							{% endif %}
 						</div>


### PR DESCRIPTION
I have included the screen-shot in the commit, you can have a look at it
- Using word-wrap, I have avoided the outflow of large texts
- This seemed better than displaying in some other way, because Bootstrap list themes are pretty good

Signed-off-by: vijeth-aradhya vijthaaa@gmail.com
