### PR TITLE
Python 2 AND 3 [WIP] (Fix #32)

### DIFF
--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -1,2 +1,2 @@
 #!../bin/python
-import exceptions as e
+from . import exceptions as e

--- a/backends/example.py
+++ b/backends/example.py
@@ -50,7 +50,7 @@
 ## future,  please  think  very carefully before designing your persistent
 ## storage, be it database tables, folders and files, or anything else.
 
-import exceptions as e
+from . import exceptions as e
 
 # initializeBackend()
 ## This method is called when the Flask application starts. Here you can do

--- a/backends/exceptions.py
+++ b/backends/exceptions.py
@@ -8,16 +8,16 @@ class ErrorException(Exception):
 	def __init__(self, value):
 		self.value = value
 	def __str__(self):
-		return unicode(self.value)
+		return str(self.value)
 
 class WarningException(Exception):
 	def __init__(self, value):
 		self.value = value
 	def __str__(self):
-		return unicode(self.value)
+		return str(self.value)
 
 class InfoException(Exception):
 	def __init__(self, value):
 		self.value = value
 	def __str__(self):
-		return unicode(self.value)
+		return str(self.value)

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -63,6 +63,13 @@ def updatePasteMetadata(pasteid, metadata):
 	ppath = "pastes/" + a + "/" + b + "/" + pasteid
 
 	try:
+		for j in os.listdir("pastes/" + a + "/" + b):
+			if ("." in j) and (pasteid in j):
+				os.remove("pastes/" + a + "/" + b + "/" + j)
+	except:
+		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")
+
+	try:
 		for k, v in metadata.iteritems():
 			with open(ppath + "." + k, "w+") as fd:
 				fd.write(v)

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -1,6 +1,6 @@
 #!../bin/python
 
-import exceptions as e
+from . import exceptions as e
 import os
 
 # initializeBackend()
@@ -70,7 +70,7 @@ def updatePasteMetadata(pasteid, metadata):
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")
 
 	try:
-		for k, v in metadata.iteritems():
+		for k, v in metadata.items():
 			with open(ppath + "." + k, "w+") as fd:
 				fd.write(v)
 	except:
@@ -120,7 +120,7 @@ def getPasteMetadata(pasteid):
 	try:
 		for f in os.listdir("pastes/" + a + "/" + b + "/"):
 			if (pasteid in f) and ("." in f):
-				t = f.split(".")[1]	
+				t = f.split(".")[1]
 				with open("pastes/" + a + "/" + b + "/" + f, "r") as fd:
 					ret[t] = fd.read()
 	except:
@@ -166,8 +166,8 @@ def getAllPasteIDs():
 					ret.append(k)
 		if ( len ( ret ) == 0 ):
 			return ['none']
-	
+
 		return ret
-	
+
 	except:
 		raise e.ErrorException("An issue occured with the local filesystem. Please try again later. If the problem persists, try notifying a system administrator.")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -26,3 +26,7 @@ span.hamburger {
     	width: 100%;
     }
 }
+
+.pastes {
+	word-wrap: break-word;
+}

--- a/templates/list.html
+++ b/templates/list.html
@@ -21,7 +21,7 @@
 							<a href="/new" class="list-group-item">No pastes yet</a>
 							{% else %}
 							{% for paste in pastes %}
-							<a href="/view/{{paste}}" class="list-group-item">{{paste}}</a>
+							<a href="/view/{{paste}}" class="list-group-item pastes">{{paste}}</a>
 							{% endfor %}
 							{% endif %}
 						</div>

--- a/templates/list.html
+++ b/templates/list.html
@@ -16,12 +16,12 @@
 				</div>
 				<div class="row">
 					<div class="col-xs-10 col-xs-offset-1">
-						<div class="list-group">
+						<div class="list-group pastes">
 							{% if "none" in pastes %}
 							<a href="/new" class="list-group-item">No pastes yet</a>
 							{% else %}
 							{% for paste in pastes %}
-							<a href="/view/{{paste}}" class="list-group-item pastes">{{paste}}</a>
+							<a href="/view/{{paste}}" class="list-group-item">{{paste}}</a>
 							{% endfor %}
 							{% endif %}
 						</div>

--- a/torpaste.py
+++ b/torpaste.py
@@ -8,7 +8,7 @@ import backends.filesystem as b
 app = Flask(__name__)
 
 WEBSITE_TITLE = "Tor Paste"
-VERSION = "0.4"
+VERSION = "0.5"
 
 @app.route('/')
 def index():

--- a/torpaste.py
+++ b/torpaste.py
@@ -55,7 +55,7 @@ def newpaste():
 				b.updatePasteMetadata(
 					PasteID,
 					{
-						"date": unicode(int(time.time()))
+						"date": str(int(time.time()))
 					}
 				)
 			except b.e.ErrorException as errmsg:

--- a/torpaste.py
+++ b/torpaste.py
@@ -31,14 +31,14 @@ def newpaste():
 	else:
 		if(request.form['content']):
 			try:
-				PasteID = str(sha256(request.form['content']).hexdigest())
+				PasteID = str(sha256(request.form['content'].encode()).hexdigest())
 			except:
 				return render_template(
 					"index.html",
 					title = WEBSITE_TITLE,
 					version = VERSION,
 					page = "new",
-					error = "The current version of TorPaste supports ASCII characters only. UTF-8 support is coming soon."
+					error = "Some stranger error occurred, sorry about that. Please try again with a different paste text."
 				)
 			try:
 				b.newPaste(PasteID, request.form['content'])


### PR DESCRIPTION
Using the `2to3` I managed to make the project compatible with both python 2.7 and 3.5.

Also, since all strings in python 3.5 are Unicode, I had to also support Unicode Characters, and it was done to both python versions with just a `.encode()`.

I didn't test if [this try/catch](https://github.com/DaKnOb/TorPaste/compare/master...carlosasj:master#diff-6d90008e4020d5d98fd715f731d3ab86R33) is still necessary, so I just changed the error message, hopefully that will never be reached.
