### PR TITLE
#32: switch to Python 3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest
 MAINTAINER Antonios A. Chariton <daknob@daknob.net>
 
-# Install Python and pip
-RUN apk add --update python py-pip
+# Install Python 3, which comes with pip3
+RUN apk add --update python3
 
 # Install a Production WSGI Web Server
-RUN pip install gunicorn
+RUN pip3 install gunicorn
 
 # Move everything inside the container
 RUN mkdir /torpaste
@@ -15,7 +15,7 @@ COPY . /torpaste/.
 WORKDIR /torpaste
 
 # Install the required software
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Expose port *80*
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:latest
 MAINTAINER Antonios A. Chariton <daknob@daknob.net>
 
-# Install Python 3, which comes with pip3
+# Install Python 3 and pip3
 RUN apk add --update python3
+RUN python3 -m ensurepip
+RUN pip3 install --upgrade pip setuptools
 
 # Install a Production WSGI Web Server
 RUN pip3 install gunicorn

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -1,2 +1,0 @@
-#!../bin/python
-import exceptions as e

--- a/backends/exceptions.py
+++ b/backends/exceptions.py
@@ -12,7 +12,7 @@ class ErrorException(Exception):
         self.value = value
 
     def __str__(self):
-        return unicode(self.value)
+        return str(self.value)
 
 
 class WarningException(Exception):
@@ -20,7 +20,7 @@ class WarningException(Exception):
         self.value = value
 
     def __str__(self):
-        return unicode(self.value)
+        return str(self.value)
 
 
 class InfoException(Exception):
@@ -28,4 +28,4 @@ class InfoException(Exception):
         self.value = value
 
     def __str__(self):
-        return unicode(self.value)
+        return str(self.value)

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -1,7 +1,7 @@
 #!../bin/python
 # -*- coding: utf-8 -*-
 
-import exceptions as e
+import backends.exceptions as e
 import os
 import codecs
 
@@ -88,7 +88,7 @@ def update_paste_metadata(paste_id, metadata):
             try notifying a system administrator.")
 
     try:
-        for k, v in metadata.iteritems():
+        for k, v in metadata.items():
             with codecs.open(ppath + "." + k, encoding="utf-8", mode="w+") as fd:
                 fd.write(v)
     except:

--- a/torpaste.py
+++ b/torpaste.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 from hashlib import sha256
 from os import getenv
+import sys
 
 from flask import *
 
@@ -73,7 +74,7 @@ def new_paste():
                 b.update_paste_metadata(
                     paste_id,
                     {
-                        "date": unicode(int(time.time()))
+                        "date": str(int(time.time()))
                     }
                 )
             except b.e.ErrorException as errmsg:
@@ -255,6 +256,10 @@ def format_size(size):
 
 
 # Required Initialization Code
+
+# necessary for local modules import (backends, exceptions)
+sys.path.append('.')
+
 # Handle Environment Variables (for configuration)
 # Web App <title>
 WEBSITE_TITLE = getenv("TP_WEBSITE_TITLE") or "Tor Paste"


### PR DESCRIPTION
Here's the full switch to Python 3. With that code, TorPaste works perfectly with both Python 2 and Python 3, but I can't write a Dockerfile that would use both... so the Dockerfile enforces Python 3.

Not much changes really, it's mostly details. I changed a bit the way local modules are imported to fix a problem with Python 3: I add TorPaste's directory to python's path, and the include is now "backends.exceptions" instead of "exceptions".
