### PR TITLE
#20: Add support for unlisted pastes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ or `16 k`. Any value that starts with `0` changes this limit to unlimited. *Defa
 `0`
 * `TP_PASTE_LIST_ACTIVE` : Use this variable to enable or disable the paste listing
 available in the `Pastes` menu. *Default:* `True`
+* `TP_ENABLED_PASTE_VISIBILITIES` : Use this variable to select the available paste
+visibilities, separated by a comma. Example: "public,unlisted". *Default:* `public`.
 
 ### Backend ENV Variables
 Each backend may need one or more additional `ENV` variables to work. For example,

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,15 @@
 					</div>
 					<div class="form-group">
 						<div class="col-xs-10 col-xs-offset-1">
+							<label for="visibility">Paste visibility: </label>
+							<select name="visibility" class="form-control">
+								<option value="public">Public</option>
+								<option value="unlisted">Unlisted</option>
+							</select>
+						</div>
+					</div>
+					<div class="form-group">
+						<div class="col-xs-10 col-xs-offset-1">
 							<input type="submit" class="btn btn-primary" value="Create New Paste">
 						</div>
 					</div>


### PR DESCRIPTION
Adding support for unlisted pastes did not require many changes. Private pastes will be more complex (it will require a different logic in the /new and /view routes), and so we'll probably need a bit of refactoring at that point...

But in the meanwhile, here's unlisted pastes.
