### PR TITLE
Add Security Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ or `16 k`. Any value that starts with `0` changes this limit to unlimited. *Defa
 `0`
 * `TP_PASTE_LIST_ACTIVE` : Use this variable to enable or disable the paste listing
 available in the `Pastes` menu. *Default:* `True`
+* `TP_CSP_REPORT_URI` : Use this variable to set a `report-uri` for the Content Security
+Policy of TorPaste. If this variable is not set, no `report-uri` is added, which is the
+default behavior.
 
 ### Backend ENV Variables
 Each backend may need one or more additional `ENV` variables to work. For example,

--- a/torpaste.py
+++ b/torpaste.py
@@ -251,6 +251,19 @@ def about_tor_paste():
     )
 
 
+@app.after_request
+def additional_headers(response):
+    response.headers["X-Frame-Options"] = "NONE"
+    response.headers["X-Xss-Protection"] = "1; mode=block"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Content-Security-Policy"] = "default-src 'none'; "
+    response.headers["Content-Security-Policy"] += "img-src 'self'; "
+    response.headers["Content-Security-Policy"] += "style-src 'self'; "
+    if (config['CSP_REPORT_URI']):
+        response.headers["Content-Security-Policy"] += "report-uri "
+        response.headers["Content-Security-Policy"] += config['CSP_REPORT_URI']
+    return response
+
 # Functions
 def format_size(size):
     scales = ["bytes", "kB", "MB", "GB", "TB", "PB"]
@@ -314,11 +327,15 @@ def load_config():
     if PASTE_LIST_ACTIVE in ["False", "false", 0, "0"]:
         PASTE_LIST_ACTIVE = False
 
+    # Content Security Policy Handling
+    CSP_REPORT_URI = getenv("TP_CSP_REPORT_URI") or False
+
     return {
         "MAX_PASTE_SIZE": MAX_PASTE_SIZE,
         "WEBSITE_TITLE": WEBSITE_TITLE,
         "PASTE_LIST_ACTIVE": PASTE_LIST_ACTIVE,
-        "b": b
+        "b": b,
+        "CSP_REPORT_URI": CSP_REPORT_URI
     }
 
 config = load_config()


### PR DESCRIPTION
This Pull Request adds the following HTTP Security Headers to TorPaste:
- `X-Frame-Options`
- `X-Xss-Protection`
- `X-Content-Type-Options`
- `Content-Security-Policy`
