### PR TITLE
#20: added support for unlisted pastes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ available in the `Pastes` menu. *Default:* `True`
 * `TP_CSP_REPORT_URI` : Use this variable to set a `report-uri` for the Content Security
 Policy of TorPaste. If this variable is not set, no `report-uri` is added, which is the
 default behavior.
+* `TP_ENABLED_PASTE_VISIBILITIES` : Use this variable to select the available paste
+visibilities, separated by a comma. Example: "public,unlisted". The available backends
+for each version are included in the `AVAILABLE_VISIBILITIES` variable inside 
+`torpaste.py`. *Default:* `public`.
 
 ### Backend ENV Variables
 Each backend may need one or more additional `ENV` variables to work. For example,

--- a/backends/example.py
+++ b/backends/example.py
@@ -156,13 +156,14 @@ def get_paste_metadata_value(paste_id, key):
         return None
 
 
-def get_all_paste_ids():
+def get_all_paste_ids(filters={}):
     """
-    This method must return a Python list containing each and every
-    Paste ID, in ASCII. The order does not matter so it can be the same
-    or it can be different every time this function is called. In the
-    case of no pastes, the method must return a Python list with a
-    single item, whose content must be equal to 'none'.
+    This method must return a Python list containing the ASCII ID of all
+    pastes which match the (optional) filters provided.The order does not
+    matter so it can be the same or it can be different every time this
+    function is called. In the case of no pastes, the method must return a
+    Python list with a single item, whose content must be equal to 'none'.
+    :param filters: a dictionnary of filters
     :return: a list containing all paste IDs
     """
 

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -217,17 +217,18 @@ def get_paste_metadata_value(paste_id, key):
         return None
 
 
-def get_all_paste_ids():
+def get_all_paste_ids(filters={}):
     """
-    This method must return a Python list containing each and every
-    Paste ID, in ASCII. The order does not matter so it can be the same
-    or it can be different every time this function is called. In the
-    case of no pastes, the method must return a Python list with a
-    single item, whose content must be equal to 'none'.
+    This method must return a Python list containing the ASCII ID of all
+    pastes which match the (optional) filters provided.The order does not
+    matter so it can be the same or it can be different every time this
+    function is called. In the case of no pastes, the method must return a
+    Python list with a single item, whose content must be equal to 'none'.
+    :param filters: a dictionnary of filters
     :return: a list containing all paste IDs
     """
 
-    ret = []
+    allPastes = []
 
     try:
         for i in os.listdir("pastes"):
@@ -239,15 +240,30 @@ def get_all_paste_ids():
                 for k in os.listdir("pastes/" + i + "/" + j):
                     if "." in k:
                         continue
-                    ret.append(k)
-        if len(ret) == 0:
-            return ['none']
-
-        return ret
-
+                    allPastes.append(k)
     except:
         raise e.ErrorException(
             "An issue occurred with the local filesystem. Please try again " +
             "later. If the problem persists, try notifying a system " +
             "administrator."
         )
+
+    filtered = []
+    for p in allPastes:
+        keep = True
+
+        try:
+            for k, v in filters.items():
+                if get_paste_metadata_value(p, k) != v:
+                    keep = False
+                    break
+        except (e.ErrorException, e.WarningException):
+            keep = False
+
+        if keep:
+            filtered.append(p)
+
+    if len(filtered) == 0:
+        filtered = ['none']
+
+    return filtered

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,12 +23,14 @@
 					</div>
 					<div class="form-group">
 						<div class="col-xs-10 col-xs-offset-1">
+							{% if config['ENABLED_PASTE_VISIBILITIES']|length > 1 %}
 							<label for="visibility">Paste visibility: </label>
 							<select name="visibility" class="form-control">
 								{% for visibility in config['ENABLED_PASTE_VISIBILITIES'] %}
-								<option value="{{visibility}}">{{visibility.capitalize()}}</option>
+								<option class="form-control" value="{{visibility}}">{{visibility.capitalize()}}</option>
 								{% endfor %}
 							</select>
+							{% endif %}
 						</div>
 					</div>
 					<div class="form-group">

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,16 @@
 					</div>
 					<div class="form-group">
 						<div class="col-xs-10 col-xs-offset-1">
+							<label for="visibility">Paste visibility: </label>
+							<select name="visibility" class="form-control">
+								{% for visibility in config['ENABLED_PASTE_VISIBILITIES'] %}
+								<option value="{{visibility}}">{{visibility.capitalize()}}</option>
+								{% endfor %}
+							</select>
+						</div>
+					</div>
+					<div class="form-group">
+						<div class="col-xs-10 col-xs-offset-1">
 							<input type="submit" class="btn btn-primary" value="Create New Paste">
 						</div>
 					</div>

--- a/torpaste.py
+++ b/torpaste.py
@@ -19,6 +19,10 @@ VERSION = check_output(["git", "describe"]).decode("utf-8").replace("\n", "")
 # Compatible Backends List
 COMPATIBLE_BACKENDS = ["filesystem"]
 
+# Available list of paste visibilities
+# public: can be viewed by all, is listed in /list
+# unlisted: can be viewed by all, is not listed in /list ("hidden")
+AVAILABLE_VISIBILITIES = ["public", "unlisted"]
 
 @app.route('/')
 def index():
@@ -43,6 +47,7 @@ def new_paste():
         if (request.form['content']):
             status, message = logic.create_new_paste(
                 request.form['content'],
+                request.form['visibility'],
                 config
             )
             if (status == "ERROR"):
@@ -181,8 +186,17 @@ def additional_headers(response):
 sys.path.append('.')
 
 
-# Handle Environment Variables (for configuration)
 def load_config():
+    """
+    This method reads all configuration variables from environment variables
+    and put them in a dictionary, which is then returned.
+    Environment variables are used for convenience when using Docker (simply add
+    an -e "TP_SOME_CONFIG_VAR=value" to docker run to modify the default 
+    configuration)
+
+    :return: the configuration dictionary
+    """
+
     # Web App <title>
     WEBSITE_TITLE = getenv("TP_WEBSITE_TITLE") or "Tor Paste"
 
@@ -232,12 +246,29 @@ def load_config():
     # Content Security Policy Handling
     CSP_REPORT_URI = getenv("TP_CSP_REPORT_URI") or False
 
+    # control the enabled paste visibilities:
+    # public = can be opened by anyone and listed in /list
+    # unlisted = can be opened by anyone, but are not listed in /list
+    visibilityEnv = "TP_ENABLED_PASTE_VISIBILITIES"
+    ENABLED_PASTE_VISIBILITIES = getenv(visibilityEnv) or 'public'
+    ENABLED_PASTE_VISIBILITIES = ENABLED_PASTE_VISIBILITIES.replace(' ', '')
+    ENABLED_PASTE_VISIBILITIES = ENABLED_PASTE_VISIBILITIES.split(',')
+    # remove any potential whitespace
+    ENABLED_PASTE_VISIBILITIES = [visibility for visibility 
+        in ENABLED_PASTE_VISIBILITIES if visibility in AVAILABLE_VISIBILITIES]
+
+
+    if len(ENABLED_PASTE_VISIBILITIES) == 0:
+        print("No valid visibilities found for pastes.")
+        exit(1)
+
     return {
         "MAX_PASTE_SIZE": MAX_PASTE_SIZE,
         "WEBSITE_TITLE": WEBSITE_TITLE,
         "PASTE_LIST_ACTIVE": PASTE_LIST_ACTIVE,
+        "CSP_REPORT_URI": CSP_REPORT_URI,
         "b": b,
-        "CSP_REPORT_URI": CSP_REPORT_URI
+        "ENABLED_PASTE_VISIBILITIES": ENABLED_PASTE_VISIBILITIES,
     }
 
 config = load_config()

--- a/torpaste.py
+++ b/torpaste.py
@@ -24,6 +24,7 @@ COMPATIBLE_BACKENDS = ["filesystem"]
 # unlisted: can be viewed by all, is not listed in /list ("hidden")
 AVAILABLE_VISIBILITIES = ["public", "unlisted"]
 
+
 @app.route('/')
 def index():
     return render_template(
@@ -47,7 +48,7 @@ def new_paste():
         if (request.form['content']):
             status, message = logic.create_new_paste(
                 request.form['content'],
-                request.form['visibility'],
+                request.form,
                 config
             )
             if (status == "ERROR"):
@@ -132,7 +133,8 @@ def raw_paste(pasteid):
 
 @app.route("/list")
 def list():
-    status, data, code = logic.get_paste_listing(config)
+    listFilters = {"visibility": "public"}
+    status, data, code = logic.get_paste_listing(config, listFilters)
 
     if (status == "ERROR"):
         return Response(
@@ -189,9 +191,9 @@ sys.path.append('.')
 def load_config():
     """
     This method reads all configuration variables from environment variables
-    and put them in a dictionary, which is then returned.
-    Environment variables are used for convenience when using Docker (simply add
-    an -e "TP_SOME_CONFIG_VAR=value" to docker run to modify the default 
+    and put them in a dictionary, which is then returned. Environment
+    variables are used for convenience when using Docker (simply add
+    an -e "TP_SOME_CONFIG_VAR=value" to docker run to modify the default
     configuration)
 
     :return: the configuration dictionary
@@ -254,9 +256,9 @@ def load_config():
     ENABLED_PASTE_VISIBILITIES = ENABLED_PASTE_VISIBILITIES.replace(' ', '')
     ENABLED_PASTE_VISIBILITIES = ENABLED_PASTE_VISIBILITIES.split(',')
     # remove any potential whitespace
-    ENABLED_PASTE_VISIBILITIES = [visibility for visibility 
-        in ENABLED_PASTE_VISIBILITIES if visibility in AVAILABLE_VISIBILITIES]
-
+    ENABLED_PASTE_VISIBILITIES = [visibility
+                                  for visibility in ENABLED_PASTE_VISIBILITIES
+                                  if visibility in AVAILABLE_VISIBILITIES]
 
     if len(ENABLED_PASTE_VISIBILITIES) == 0:
         print("No valid visibilities found for pastes.")
@@ -267,8 +269,8 @@ def load_config():
         "WEBSITE_TITLE": WEBSITE_TITLE,
         "PASTE_LIST_ACTIVE": PASTE_LIST_ACTIVE,
         "CSP_REPORT_URI": CSP_REPORT_URI,
-        "b": b,
         "ENABLED_PASTE_VISIBILITIES": ENABLED_PASTE_VISIBILITIES,
+        "b": b
     }
 
 config = load_config()


### PR DESCRIPTION
I rebased the unlisted paste feature on top of the recent changes.

I also added a PEP8-style comment for `load_config` instead of a single `#comment`, and added a `visibility` param to `create_new_paste`.

Finally, I also deleted the file `pastes\.pastes` because it was empty and not referenced anywhere, and so I thought I had created it by mistake. But now I see it appears in the diff here, so it was there before, so maybe it should be kept?
