### PR TITLE
Switch to flake8 linter and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ python:
     - "3.5-dev"
     - "3.6-dev"
     - "nightly"
-install: pip install pep8
-script: pep8 .
+install: pip install flake8
+script: flake8 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,13 @@ Try to keep it clear and concise.
 We use [PEP8](https://www.python.org/dev/peps/pep-0008/) as coding style
 convention. There's probably no need to read the whole thing, though: just
 make sure your code looks like what's already there. You can install a command
-line utility called `pep8` using:
+line utility called `flake8` using:
 
 ```bash
-sudo pip install pep8
+sudo pip install flake8
 ```
 
-Afterwards, by running `pep8 file.py` you will see all the changes you must
+Afterwards, by running `flake8 file.py` you will see all the changes you must
 make in order to be fully compliant.
 
 One method you can follow is write your code, but before you commit it, open
@@ -54,10 +54,10 @@ two windows, side by side, one having your editor, and the other being a
 terminal. Afterwards, run in the terminal:
 
 ```bash
-watch -n1 pep8 file.py
+watch -n1 flake8 file.py
 ```
 
-This will show you the output of the `pep8` command and it will automatically
+This will show you the output of the `flake8` command and it will automatically
 update every one second, so as soon as you save your file, you will see the
 changes being reflected in the command output. If you run macOS and don't have
 `watch` installed, you can install it by using `brew install watch`.

--- a/torpaste.py
+++ b/torpaste.py
@@ -188,6 +188,7 @@ def additional_headers(response):
         response.headers["Content-Security-Policy"] += config['CSP_REPORT_URI']
     return response
 
+
 # Required Initialization Code
 
 # necessary for local modules import (backends, exceptions)
@@ -279,6 +280,7 @@ def load_config():
         "b": b
     }
 
+
 config = load_config()
 b = config['b']
 
@@ -288,6 +290,7 @@ try:
 except:
     print("Failed to initialize backend")
     exit(1)
+
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0")

--- a/torpaste.py
+++ b/torpaste.py
@@ -9,7 +9,11 @@ import sys
 import logic
 from subprocess import check_output
 
-from flask import *
+from flask import Flask
+from flask import Response
+from flask import redirect
+from flask import render_template
+from flask import request
 
 app = Flask(__name__)
 


### PR DESCRIPTION
The flake8 linter is a wrapper around pep8 and pyflakes. In addition to checking for PEP style compliance, flake8 will also find bugs with an essentially zero false positive rate.

As such, it's well worth running the flake8 linter instead of pep8. A full listing of the issues that flake will detect can be found [here](http://flake8.pycqa.org/en/latest/user/error-codes.html).