### PR TITLE
Fix error: module 'os' has no attribute 'mkdirs'

### DIFF
--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -14,7 +14,7 @@ def initialize_backend():
     """
 
     try:
-        os.mkdirs("pastes")
+        os.makedirs("pastes", exist_ok=True)
     except:
         pass
     return

--- a/backends/filesystem.py
+++ b/backends/filesystem.py
@@ -13,11 +13,7 @@ def initialize_backend():
     such as connecting to a remote database or making sure a file exists.
     """
 
-    try:
-        os.makedirs("pastes", exist_ok=True)
-    except:
-        pass
-    return
+    os.makedirs("pastes", exist_ok=True)
 
 
 def new_paste(paste_id, paste_content):
@@ -36,10 +32,7 @@ def new_paste(paste_id, paste_content):
     a = paste_id[0:2]
     b = paste_id[2:4]
 
-    try:
-        os.makedirs("pastes/" + a + "/" + b)
-    except:
-        pass
+    os.makedirs("pastes/" + a + "/" + b, exist_ok=True)
 
     ppath = "pastes/" + a + "/" + b + "/" + paste_id
 
@@ -77,10 +70,7 @@ def update_paste_metadata(paste_id, metadata):
     a = paste_id[0:2]
     b = paste_id[2:4]
 
-    try:
-        os.makedirs("pastes/" + a + "/" + b)
-    except:
-        pass
+    os.makedirs("pastes/" + a + "/" + b, exist_ok=True)
 
     ppath = "pastes/" + a + "/" + b + "/" + paste_id
 


### PR DESCRIPTION
Without this fix, the `initialize_backend` method fails with the error being silently swallowed by the broad except block.

In order to avoid these sorts of exception masking issues going forward, commit ff68452 also removes the except blocks that wrap the `os.makedirs` calls in favor of the `exist_ok` flag so that the only exceptions that get ignored are ones related to the directory already existing. The `exist_ok` argument was added in Python 3.2 ([source](https://docs.python.org/3/library/os.html#os.makedirs)). Given that this project supports Python 3.5+, it should be fine to use this flag.