### PR TITLE
Add AWS S3 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ The backend is activated by setting `TP_BACKEND=azure_storage`. Each paste is
 stored as a separate blob which means that this backend supports paste sizes [up to 5TB](https://docs.microsoft.com/en-us/azure/storage/common/storage-scalability-targets).
 Metadata associated with a paste is stored directly on the blob via [custom metadata fields](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-properties-metadata).
 
+### aws_s3
+This is a backend based on the Amazon AWS S3 storage system. The backend is activated
+by setting `TP_BACKEND=aws_s3`. Each paste is stored as a separate Amazon S3 object and
+has data, a key, and metadata. The key (paste_id) uniquely identifies the object
+(paste) in a bucket. Object metadata is a set of name-value pairs that cannot be
+modified but can be replaced by a metadata copy.
+
 ## Configuration
 TorPaste can be configured by using `ENV`ironment Variables. The list of available
 variables as well as their actions is below so you can use them to parameterize your
@@ -158,3 +165,17 @@ and how to set up a storage account [here](https://docs.microsoft.com/en-us/azur
   exist, it will be created. *Default:* `torpaste`.
 * `TP_BACKEND_AZURE_STORAGE_TIMEOUT_SECONDS` : Use this variable to set the
   timeout in seconds for all requests to Azure. *Default:* `10`.
+
+### aws_s3
+
+This backend assumes that you have an Amazon S3 subscription and a storage account
+in that subscription. You can learn how to set up a new subscription and how to
+set up a storage account [here](http://docs.aws.amazon.com/AmazonS3/latest/gsg/SigningUpforS3.html).
+
+* `TP_BACKEND_AWS_S3_ACCESS_KEY_ID` : Use this variable to set the key id of the
+  Amazon AWS S3 account to use.
+* `TP_BACKEND_AWS_S3_SECRET_ACCESS_KEY` : Use this variable to set the secret key
+  of the Amazon AWS S3 account to use.
+* `TP_BACKEND_AWS_S3_BUCKET` : Use this variable to set the name of the container
+  in which to store pastes and metadata. If the container does not exist, it will
+  be created. Default: torpaste.

--- a/backends/aws_s3.py
+++ b/backends/aws_s3.py
@@ -1,0 +1,125 @@
+from functools import wraps
+from os import environ
+from os import getenv
+
+import boto3
+from botocore.exceptions import ClientError
+
+from backends.exceptions import ErrorException
+
+_ENV_ACCESS_KEY_ID = 'TP_BACKEND_AWS_S3_ACCESS_KEY_ID'
+_ENV_SECRET_ACCESS_KEY = 'TP_BACKEND_AWS_S3_SECRET_ACCESS_KEY'
+_ENV_BUCKET = 'TP_BACKEND_AWS_S3_BUCKET'
+
+_DEFAULT_BUCKET = 'torpaste'
+
+_s3 = None
+_bucket = None
+
+
+def _wrap_aws_exception(func):
+    @wraps(func)
+    def _adapt_exception_types(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ClientError as ex:
+            raise ErrorException(
+                'Error while communicating with AWS S3') from ex
+
+    return _adapt_exception_types
+
+
+def _getenv_required(key):
+    try:
+        return environ[key]
+    except KeyError:
+        raise ErrorException(
+            'Required environment variable %s not set' % key)
+
+
+@_wrap_aws_exception
+def initialize_backend():
+    global _s3
+    global _bucket
+
+    _s3 = boto3.resource(
+        's3',
+        aws_access_key_id=_getenv_required(_ENV_ACCESS_KEY_ID),
+        aws_secret_access_key=_getenv_required(_ENV_SECRET_ACCESS_KEY))
+
+    _bucket = getenv(_ENV_BUCKET, _DEFAULT_BUCKET)
+    _s3.create_bucket(Bucket=_bucket)
+
+
+@_wrap_aws_exception
+def new_paste(paste_id, paste_content):
+    _s3.Bucket(_bucket).put_object(
+        Body=paste_content.encode('utf-8'),
+        Key=paste_id)
+
+
+@_wrap_aws_exception
+def update_paste_metadata(paste_id, metadata):
+    obj = _s3.Object(_bucket, paste_id)
+    obj.metadata.clear()
+    obj.metadata.update(metadata)
+    obj.copy_from(CopySource={'Bucket': _bucket, 'Key': paste_id},
+                  Metadata=obj.metadata,
+                  MetadataDirective='REPLACE')
+
+
+@_wrap_aws_exception
+def does_paste_exist(paste_id):
+    try:
+        _s3.Object(_bucket, paste_id).load()
+    except ClientError as ex:
+        if ex.response['Error']['Code'] != '404':
+            raise
+        else:
+            return False
+    else:
+        return True
+
+
+@_wrap_aws_exception
+def get_paste_contents(paste_id):
+    body = _s3.Object(_bucket, paste_id).get()['Body'].read()
+    return body.decode('utf-8')
+
+
+@_wrap_aws_exception
+def get_paste_metadata(paste_id):
+    obj = _s3.Object(_bucket, paste_id)
+    obj.load()
+    return obj.metadata
+
+
+@_wrap_aws_exception
+def get_paste_metadata_value(paste_id, key):
+    return get_paste_metadata(paste_id).get(key)
+
+
+def _filters_match(metadata, filters, fdefaults):
+    for metadata_key, filter_value in filters.items():
+        try:
+            metadata_value = metadata[metadata_key]
+        except KeyError:
+            metadata_value = fdefaults.get(metadata_key)
+
+        if metadata_value != filter_value:
+            return False
+
+    return True
+
+
+def _get_all_paste_ids(filters, fdefaults):
+    for obj in _s3.Bucket(_bucket).objects.all():
+        paste_id = obj.key
+        metadata = get_paste_metadata(paste_id)
+        if _filters_match(metadata, filters, fdefaults):
+            yield paste_id
+
+
+@_wrap_aws_exception
+def get_all_paste_ids(filters={}, fdefaults={}):
+    return list(_get_all_paste_ids(filters, fdefaults))

--- a/backends/aws_s3.py
+++ b/backends/aws_s3.py
@@ -105,4 +105,4 @@ def _get_all_paste_ids(filters, fdefaults):
 
 @_wrap_aws_exception
 def get_all_paste_ids(filters={}, fdefaults={}):
-    return list(_get_all_paste_ids(filters, fdefaults))
+    return list(_get_all_paste_ids(filters, fdefaults)) or ['none']

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -1,0 +1,38 @@
+from functools import wraps
+from os import environ
+
+from backends.exceptions import ErrorException
+
+
+def wrap_exception(exception_type, error_message):
+    def _typed_exception_wrapper(func):
+        @wraps(func)
+        def _adapt_exception_types(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exception_type as ex:
+                raise ErrorException(error_message) from ex
+        return _adapt_exception_types
+    return _typed_exception_wrapper
+
+
+def getenv_required(key):
+    try:
+        return environ[key]
+    except KeyError:
+        raise ErrorException(
+            'Required environment variable %s not set' % key)
+
+
+def getenv_int(key, default):
+    try:
+        value = environ[key]
+    except KeyError:
+        return default
+
+    try:
+        return int(value)
+    except ValueError:
+        raise ErrorException(
+            'Environment variable %s with value %s '
+            'is not convertible to int' % (key, value))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 azure-storage==0.36.0
+boto3==1.4.7

--- a/torpaste.py
+++ b/torpaste.py
@@ -21,7 +21,11 @@ app = Flask(__name__)
 VERSION = check_output(["git", "describe"]).decode("utf-8").replace("\n", "")
 
 # Compatible Backends List
-COMPATIBLE_BACKENDS = ["filesystem", "azure_storage", "aws_s3"]
+COMPATIBLE_BACKENDS = [
+    "filesystem",
+    "azure_storage",
+    "aws_s3",
+]
 
 # Available list of paste visibilities
 # public: can be viewed by all, is listed in /list

--- a/torpaste.py
+++ b/torpaste.py
@@ -21,10 +21,7 @@ app = Flask(__name__)
 VERSION = check_output(["git", "describe"]).decode("utf-8").replace("\n", "")
 
 # Compatible Backends List
-COMPATIBLE_BACKENDS = [
-    "filesystem",
-    "azure_storage",
-]
+COMPATIBLE_BACKENDS = ["filesystem", "azure_storage", "aws_s3"]
 
 # Available list of paste visibilities
 # public: can be viewed by all, is listed in /list


### PR DESCRIPTION
This pull request adds a storage backend based on Amazon AWS S3 storage system. See #15

The AWS S3 storage system allows us to treat:
- Each `paste` as an Amazon S3 `object`
- Each `past_id` as an object `key` (or key name)
- Each `metadata` as an object `metadata` (which is accessible in a limited way, and which cannot be merely modified)

You find more information regarding Amazon S3 objects and their data, key, and metadata [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html).

Due to the lack of options, this PR does not implement any preventive approach for each communication with the Amazon S3 storage (e.g. setting a timeout).

This should be merged after #66 so that unrelated lint errors are fixed.

Pair-programmed with @c-w 