### PR TITLE
Fix get_all_paste_ids in no-pastes case

### DIFF
--- a/backends/azure_storage.py
+++ b/backends/azure_storage.py
@@ -137,4 +137,4 @@ def _get_all_paste_ids(filters, fdefaults):
 
 @_wrap_azure_exception
 def get_all_paste_ids(filters={}, fdefaults={}):
-    return list(_get_all_paste_ids(filters, fdefaults))
+    return list(_get_all_paste_ids(filters, fdefaults)) or ['none']


### PR DESCRIPTION
According to the [specification](https://github.com/DaKnOb/TorPaste/blob/c0cb489d40a57ad18a8285ea41485e7df9a81221/backends/example.py#L164-L165), we should return a list with a single item "none" instead of an empty list if no pastes exist.